### PR TITLE
Add Rails 4 support

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -21,6 +21,10 @@ A multi-database connection scheme for Rails 3, supporting testing and migration
 
 * gem "use_db", "~> 0.2.0"
 
+=== Rails 4.x
+
+* gem "use_db", "~> 0.3.0"
+
 == Usage
 
 === ACTIVERECORD

--- a/README.rdoc
+++ b/README.rdoc
@@ -21,14 +21,6 @@ A multi-database connection scheme for Rails 3, supporting testing and migration
 
 * gem "use_db", "~> 0.2.0"
 
-== Install
-
-Put this line in your Gemfile:
-  gem 'use_db'
-
-Then bundle:
-  % bundle
-
 == Usage
 
 === ACTIVERECORD

--- a/README.rdoc
+++ b/README.rdoc
@@ -11,9 +11,15 @@ A multi-database connection scheme for Rails 3, supporting testing and migration
 
 == Supported versions
 
-* Ruby 1.9.2
+=== Ruby 1.9.2
 
-* Rails 3.0.x
+=== Rails 3.0
+
+* gem "use_db", "~> 0.1.4"
+
+=== Rails 3.1
+
+* gem "use_db", "~> 0.2.0"
 
 == Install
 

--- a/lib/migration.rb
+++ b/lib/migration.rb
@@ -1,21 +1,30 @@
 module ActiveRecord
   class Migration
     class << self
-      def method_missing(method, *arguments, &block)
-        say_with_time "#{method}(#{arguments.map { |a| a.inspect }.join(", ")})" do
-          arguments[0] = Migrator.proper_table_name(arguments.first) unless arguments.empty? || method == :execute
-          if (self.respond_to?(:database_model))
-           write "Using custom database model's connection (#{self.database_model}) for this migration"
-           eval("#{self.database_model}.connection.send(method, *arguments, &block)")
-          else
-           ActiveRecord::Base.connection.send(method, *arguments, &block)
-          end
-        end
-      end
-
       def uses_db?
         true
       end
     end
+
+    # New for Rails 3.1
+    def method_missing(method, *arguments, &block)
+      arg_list = arguments.map{ |a| a.inspect } * ', '
+
+      say_with_time "#{method}(#{arg_list})" do
+        unless arguments.empty? || method == :execute
+          arguments[0] = Migrator.proper_table_name(arguments.first)
+        end
+        return super unless connection.respond_to?(method)
+
+        if (respond_to?(:database_model))
+          write "Using custom database model's connection (#{database_model}) for this migration"
+          eval("#{database_model}.connection.send(method, *arguments, &block)")
+        else
+          connection.send(method, *arguments, &block)
+        end
+
+      end
+    end
+
   end
 end

--- a/lib/migration.rb
+++ b/lib/migration.rb
@@ -6,13 +6,12 @@ module ActiveRecord
       end
     end
 
-    # New for Rails 3.1
     def method_missing(method, *arguments, &block)
       arg_list = arguments.map{ |a| a.inspect } * ', '
 
       say_with_time "#{method}(#{arg_list})" do
         unless arguments.empty? || method == :execute
-          arguments[0] = Migrator.proper_table_name(arguments.first)
+          arguments[0] = proper_table_name(arguments.first)
         end
         return super unless connection.respond_to?(method)
 

--- a/lib/use_db/version.rb
+++ b/lib/use_db/version.rb
@@ -1,3 +1,3 @@
 module UseDb
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end

--- a/lib/use_db/version.rb
+++ b/lib/use_db/version.rb
@@ -1,3 +1,3 @@
 module UseDb
-  VERSION = "0.1.4"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
Hi,
In Rails 4 `Migrator.proper_table_name` was deprecated, to fix it we need to start using `Migration#proper_table_name`.

If you still maintain the project do you want to keep changes for each Rails version at separate branch?
